### PR TITLE
UNTESTED: Fix incorrect hashes

### DIFF
--- a/src/crypto/ed25519.rs
+++ b/src/crypto/ed25519.rs
@@ -1,10 +1,10 @@
 use core::ptr::write_bytes;
 
-use crate::app_error::{AppError, to_result};
+use crate::app_error::{to_result, AppError};
 use crate::crypto::bip32::Bip32Path;
 use crate::crypto::curves::{
-    Curve, cx_ecfp_private_key_t, cx_ecfp_public_key_t, cx_err_t, cx_md_t, CX_SHA512,
-    generate_key_pair, size_t,
+    cx_ecfp_private_key_t, cx_ecfp_public_key_t, cx_err_t, cx_md_t, generate_key_pair, size_t,
+    Curve, CX_SHA512,
 };
 use crate::crypto::key_pair::InternalKeyPair;
 

--- a/src/crypto/secp256k1.rs
+++ b/src/crypto/secp256k1.rs
@@ -1,8 +1,8 @@
 use core::ptr::write_bytes;
 
 use nanos_sdk::bindings::{
-    cx_ecfp_private_key_t, cx_err_t, cx_md_t, CX_ECCINFO_PARITY_ODD, CX_LAST, CX_RND_RFC6979,
-    CX_SHA256,
+    cx_ecfp_private_key_t, cx_err_t, cx_md_t, CX_ECCINFO_PARITY_ODD, CX_LAST, CX_NONE,
+    CX_RND_RFC6979,
 };
 
 use crate::app_error::{to_result, AppError};
@@ -110,7 +110,7 @@ impl KeyPairSecp256k1 {
             let rc = cx_ecdsa_sign_no_throw(
                 &self.origin.private,
                 CX_RND_RFC6979 | CX_LAST,
-                CX_SHA256,
+                CX_NONE,
                 message.as_ptr(),
                 message.len() as size_t,
                 der.as_mut_ptr(),


### PR DESCRIPTION
Wrong hash was used, we should never use `SHA256`, we should ALWAYS use `Blake2b` disregarding of curve (and then just before signing, we finalize with SHA512 just before for `EdDSA` (not for `secp256k1`).