### PR TITLE
Fix/deployment rework

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,3 +1,7 @@
+[unstable]
+build-std = ["core"]
+build-std-features = ["compiler-builtins-mem"]
+
 # Usefult for debugging image size issues. Uncomment line below when necessary.
 [build]
 # rustflags = ["-Clink-args=-Map=./target/nanos/debug/babylon-ledger-app.map"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,29 +20,11 @@ lto = false
 opt-level = "z"
 lto = false
 
-[package.metadata.nanos]
+[package.metadata.ledger]
 curve = ["secp256k1", "ed25519"]
 flags = "0x240"
-icon = "icons/nanos_app_radix.gif"
-icon_small = "icons/nanos_app_radix.gif"
 path = ["44'/1022'"]
 name = "Radix Babylon"
-api_level = "1"
-
-[package.metadata.nanox]
-curve = ["secp256k1", "ed25519"]
-flags = "0x240"
-icon = "icons/nanox_app_radix.gif"
-icon_small = "icons/nanox_app_radix.gif"
-path = ["44'/1022'"]
-name = "Radix Babylon"
-api_level = "1"
-
-[package.metadata.nanosplus]
-curve = ["secp256k1", "ed25519"]
-flags = "0x240"
-icon = "icons/nanox_app_radix.gif"
-icon_small = "icons/nanox_app_radix.gif"
-path = ["44'/1022'"]
-name = "Radix Babylon"
-api_level = "1"
+nanos.icon = "icons/nanos_app_radix.gif"
+nanox.icon = "icons/nanox_app_radix.gif"
+nanosplus.icon = "icons/nanox_app_radix.gif"


### PR DESCRIPTION
- Always set `build-std=core` in `config.toml` 
- Use (upcoming, see https://github.com/LedgerHQ/cargo-ledger/pull/30) a more general metadata format

These will allow using `cargo ledger` in a way compatible with our deployment pipeline once the above `cargo-ledger` PR is merged